### PR TITLE
fix last comments showing first comments instead

### DIFF
--- a/features/feature_change_record/src/main/java/com/example/util/simpletimetracker/feature_change_record/interactor/ChangeRecordViewDataInteractor.kt
+++ b/features/feature_change_record/src/main/java/com/example/util/simpletimetracker/feature_change_record/interactor/ChangeRecordViewDataInteractor.kt
@@ -47,7 +47,7 @@ class ChangeRecordViewDataInteractor @Inject constructor(
     ): List<ViewHolderType> {
         return recordInteractor.getByTypeWithComment(listOf(typeId))
             .asSequence()
-            .sortedBy { it.timeStarted }
+            .sortedByDescending { it.timeStarted }
             .map { it.comment }
             .toSet()
             .take(LAST_COMMENTS_TO_SHOW)


### PR DESCRIPTION
the "last comments" section when editing a record displays the first X comments rather than the last X comments. presuming this wasn't the intended outcome, I sorted the list of comments in descending order instead to display the correct comments.