### PR TITLE
Fix NPE on devices that don't support widgets

### DIFF
--- a/features/feature_widget/src/main/java/com/example/util/simpletimetracker/feature_widget/interactor/WidgetManager.kt
+++ b/features/feature_widget/src/main/java/com/example/util/simpletimetracker/feature_widget/interactor/WidgetManager.kt
@@ -56,7 +56,8 @@ class WidgetManager @Inject constructor(
         providers.forEach { provider ->
             val intent = Intent(context, provider)
             intent.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
-            val ids = AppWidgetManager.getInstance(context).getAppWidgetIds(ComponentName(context, provider))
+            val ids = AppWidgetManager.getInstance(context)
+                ?.getAppWidgetIds(ComponentName(context, provider)) ?: intArrayOf()
             intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
             context.sendBroadcast(intent)
         }


### PR DESCRIPTION
Turns out, `AppWidgetManager.getInstance(context)` can return null. I've tested that this change fixes the issue on the device.