### PR TITLE
Clamp records to time range when filtering by time

### DIFF
--- a/core/src/main/java/com/example/util/simpletimetracker/core/interactor/RecordFilterInteractor.kt
+++ b/core/src/main/java/com/example/util/simpletimetracker/core/interactor/RecordFilterInteractor.kt
@@ -260,8 +260,9 @@ class RecordFilterInteractor @Inject constructor(
             // For records spanning multiple days (eg. 48+ hours), we need to split it into multiple records
             // in order to support clamping because there will be two regions that intersect with the time range.
             calendar.timeInMillis = timeOfDay.timeStarted + timeMapper.getStartOfDayTimeStamp(timeStarted, calendar)
+            val timeRangeLength = timeOfDay.timeEnded - timeOfDay.timeStarted
             while (calendar.timeInMillis < timeEnded) {
-                val filterRange = Range(calendar.timeInMillis, calendar.timeInMillis + timeOfDay.timeEnded)
+                val filterRange = Range(calendar.timeInMillis, calendar.timeInMillis + timeRangeLength)
                 if (rangeMapper.isRecordInRange(this, filterRange))
                 filteredRecords.add(rangeMapper.clampRecordToRange(this, filterRange))
                 calendar.add(Calendar.DATE, 1)

--- a/domain/src/main/java/com/example/util/simpletimetracker/domain/mapper/RangeMapper.kt
+++ b/domain/src/main/java/com/example/util/simpletimetracker/domain/mapper/RangeMapper.kt
@@ -25,6 +25,13 @@ class RangeMapper @Inject constructor() {
         return records.filter { it.isInRange(range) }
     }
 
+    fun isRecordInRange(
+        record: RecordBase,
+        range: Range,
+    ): Boolean {
+        return record.isInRange(range)
+    }
+
     fun clampToRange(
         record: RecordBase,
         range: Range,


### PR DESCRIPTION
I think there should be a feature to clamp time records to the filtered time range instead of including the full record length. This way, it's possible to get statistics for that specific time range (eg. Activity Durations) instead of displaying the full activity.

Scenarios in which this is useful:
Let's say I have a Work record that typically goes from 900-1700. On one day, the record goes from 900-1900.
If I filter the time range from 1700-2200 then I will see this 10 hour Work record even though I'm more interested in the time range after work and would expect to only see 2 hours of Work.

There are a handful of changes in this pull request:
1. Return RecordBase? instead of Boolean in the filter methods. This allows us to make changes to the records returned.
2. Update the selectedByTimeOfDay method to clamp records to the filtered time range and potentially output multiple records for records that span multiple days.
3. Use mapNotNull and flatten instead of filter in order to convert the List<List<RecordBase>?> to List<RecordBase>