### PR TITLE
fix: Fix alignment of arrow icon in prev/next buttons

### DIFF
--- a/features/feature_records/src/main/res/layout/records_container_fragment.xml
+++ b/features/feature_records/src/main/res/layout/records_container_fragment.xml
@@ -38,6 +38,8 @@
             style="@style/ContainerRangeButton"
             android:layout_width="0dp"
             android:layout_marginStart="8dp"
+            app:iconGravity="textStart"
+            app:iconPadding="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/btnRecordsContainerToday"
             app:layout_constraintStart_toStartOf="parent" />
@@ -57,7 +59,8 @@
             android:layout_width="0dp"
             android:layout_marginEnd="8dp"
             app:icon="@drawable/arrow_right"
-            app:iconGravity="end"
+            app:iconGravity="textEnd"
+            app:iconPadding="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/btnRecordsContainerToday" />

--- a/features/feature_statistics/src/main/res/layout/statistics_container_fragment.xml
+++ b/features/feature_statistics/src/main/res/layout/statistics_container_fragment.xml
@@ -17,6 +17,8 @@
         style="@style/ContainerRangeButton"
         android:layout_width="0dp"
         android:layout_marginStart="8dp"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/btnStatisticsContainerToday"
         app:layout_constraintStart_toStartOf="parent" />
@@ -45,7 +47,8 @@
         android:layout_width="0dp"
         android:layout_marginEnd="8dp"
         app:icon="@drawable/arrow_right"
-        app:iconGravity="end"
+        app:iconGravity="textEnd"
+        app:iconPadding="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_weight="1"

--- a/features/feature_statistics_detail/src/main/res/layout/statistics_detail_fragment.xml
+++ b/features/feature_statistics_detail/src/main/res/layout/statistics_detail_fragment.xml
@@ -102,6 +102,8 @@
         style="@style/ContainerRangeButton"
         android:layout_width="0dp"
         android:layout_marginStart="8dp"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
         app:layout_constraintBottom_toBottomOf="@id/btnStatisticsDetailToday"
         app:layout_constraintEnd_toStartOf="@id/btnStatisticsDetailToday"
         app:layout_constraintStart_toStartOf="parent" />
@@ -130,7 +132,8 @@
         android:layout_width="0dp"
         android:layout_marginEnd="8dp"
         app:icon="@drawable/arrow_right"
-        app:iconGravity="end"
+        app:iconGravity="textEnd"
+        app:iconPadding="0dp"
         app:layout_constraintBottom_toBottomOf="@id/btnStatisticsDetailToday"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/btnStatisticsDetailToday" />


### PR DESCRIPTION
By using a combination of `iconGravity=textStart` and `iconPadding=0dp`, I managed to center the arrow icons in the previous/next buttons in the time range navigation bar.

![](https://github.com/user-attachments/assets/96a2173a-79b1-4ea1-865a-789ab5e9ccbc)

---

After logging 42k records in STT, it's time for me to start being more involved in this project 😃. This PR marks my first time using Android Studio, hopefully I can progress rapidly to take on more difficult tasks. As always, thanks @Razeeman for this amazing application!