### PR TITLE
Add timezone when exporting CSV

### DIFF
--- a/buildSrc/src/main/kotlin/com/example/util/simpletimetracker/Base.kt
+++ b/buildSrc/src/main/kotlin/com/example/util/simpletimetracker/Base.kt
@@ -7,7 +7,7 @@ object Base {
     // Raise by 2 to account for wear version code.
     const val versionCode = 71
     const val versionName = "1.46"
-    const val minSDK = 21
+    const val minSDK = 24
     const val currentSDK = 34
 
     const val versionCodeWear = versionCode + 1

--- a/data_local/src/main/java/com/example/util/simpletimetracker/data_local/resolver/CsvRepoImpl.kt
+++ b/data_local/src/main/java/com/example/util/simpletimetracker/data_local/resolver/CsvRepoImpl.kt
@@ -242,6 +242,6 @@ class CsvRepoImpl @Inject constructor(
     companion object {
         private const val CSV_HEADER = "activity name,time started,time ended,comment,categories,record tags,duration,duration minutes\n"
 
-        private val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+        private val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US)
     }
 }


### PR DESCRIPTION
Exported CSV file is missing timezone information, so it's hard to make sense of the data unless you know the exact timezone it was exported with.

This PR changes timestamp format to ISO8601/RFC3339, so it should be parseable by virtually any tool. (Unfortunately `XXX` requires API level 24 but I assume that's fine.)