### PR TITLE
Update French translation for statistics page - Needing help 😊

### DIFF
--- a/resources/src/main/res/values-fr/strings.xml
+++ b/resources/src/main/res/values-fr/strings.xml
@@ -556,7 +556,7 @@ Exemple :<br/>
     <string name="statistics_detail_data_split_pie_chart">Secteurs</string>
     <string name="statistics_detail_data_split_bar_chart">Colonnes</string>
     <string name="statistics_detail_day_split_hint">Répartition</string>
-    <string name="statistics_detail_duration_split_hint">Répartition de la durée des enregistrements</string>
+    <string name="statistics_detail_duration_split_hint">Répartition des enregistrements par durée</string>
     <string name="statistics_detail_next_activities_hint">Activités suivantes</string>
     <string name="statistics_detail_multitasking_activities_hint">Classement multi-tâches</string>
     <string name="statistics_detail_goals_hint">Avance ou retard par rapport à l\'objectif</string>


### PR DESCRIPTION
Hi,

**I'm trying to understand and improve french translation for app stats page.**
Yet I have performed 3 changes, I'm 90% sure 😁.

Can you please help me perform next improvement (see yellow part of the screenshot below):
<img width="1080" height="2340" alt="TOTAL" src="https://github.com/user-attachments/assets/b0521947-9d96-4fa3-9b1a-f09ef94b5eb5" />

As far as I understand, the 'Total' label here is not a total but a "time difference" (ie subtraction).
I suggest to change it to short label "Différence" or "Résultat" for french (I'm still in reflection yet) but do I need to change (extract for the default / en language file):

**string name="statistics_total_tracked_short">Total</string>** (1)

or

**string name="statistics_detail_total_duration">Total</string>** (2)

or does **this change requires to add a new string in the translation file?** (3)

These proposed changes can also be "ideas" to improve other translations and main / English labels in particular.